### PR TITLE
DEV-37966: Refactor token handling in WebSocketConnector

### DIFF
--- a/src/main/java/nps/id/publicapi/java/client/connection/WebSocketConnector.java
+++ b/src/main/java/nps/id/publicapi/java/client/connection/WebSocketConnector.java
@@ -29,7 +29,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.channels.ClosedChannelException;
 import java.time.Duration;
-import java.util.*;
+import java.util.Collections;
+import java.util.Date;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -78,11 +79,10 @@ public class WebSocketConnector {
 
         try {
             var uri = constructBaseUri();
-            var authToken = ssoService.getAuthToken();
-            var connectionHeaders = StompMessageFactory.connectionHeaders(authToken, webSocketOptions.getHeartbeatOutgoingInterval());
+            currentToken = ssoService.getAuthToken();
+            var connectionHeaders = StompMessageFactory.connectionHeaders(currentToken, webSocketOptions.getHeartbeatOutgoingInterval());
             var completableFuture = webSocketStompClient.connectAsync(uri, null, connectionHeaders, new StompSessionHandlerAdapterImpl());
             stompSession = completableFuture.get(10, TimeUnit.SECONDS);
-            currentToken = ssoService.getCurrentAuthToken();
         } catch (Exception e) {
             LOGGER.error(e);
         }

--- a/src/main/java/nps/id/publicapi/java/client/security/SsoService.java
+++ b/src/main/java/nps/id/publicapi/java/client/security/SsoService.java
@@ -31,9 +31,6 @@ public class SsoService {
 
     private final CredentialsOptions credentialsOptions;
 
-    @Getter
-    private String currentAuthToken = null;
-
     public SsoService(HttpClient httpClient, ObjectMapper objectMapper, SsoOptions ssoOptions, CredentialsOptions credentialsOptions)
     {
         this.httpClient = httpClient;
@@ -62,8 +59,7 @@ public class SsoService {
                     .build();
 
             var response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString());
-            currentAuthToken = objectMapper.readValue(response.body(), AccessTokenResponse.class).getAccessToken();
-            return currentAuthToken;
+            return objectMapper.readValue(response.body(), AccessTokenResponse.class).getAccessToken();
         } catch (JsonProcessingException e) {
             throw new TokenRequestFailedException("Failed to read auth token response body!", e);
         } catch(InterruptedException | IOException e) {


### PR DESCRIPTION
Refactor token management in WebSocketConnector. The function periodicallyRefreshToken() was not functioning as expected for PMD API. The prior token from PMD API was being erroneously overwritten by the current token from Trading API.